### PR TITLE
feat: remove claiming lp fees in harvest

### DIFF
--- a/src/PearlLPCompounder.sol
+++ b/src/PearlLPCompounder.sol
@@ -45,7 +45,7 @@ contract PearlLPCompounder is BaseHealthCheck, CustomStrategyTriggerBase {
 
     uint256 public keepPEARL; // 0 is default. the percentage of PEARL we re-lock for boost (in basis points)
     /// @notice Value in PEARL
-    uint256 public minRewardsToSell = 3e18; // ~ $1
+    uint256 public minRewardsToSell = 6e18; // ~ $2
     /// @notice Max amount of PEARL to sell in single swap
     uint256 public maxRewardsToSell = 1e20; // ~ $33
     /// @notice Value in BPS

--- a/src/interfaces/IStrategyInterface.sol
+++ b/src/interfaces/IStrategyInterface.sol
@@ -36,10 +36,6 @@ interface IStrategyInterface is IStrategy {
 
     function useCurveStable() external view returns (bool);
 
-    function setMinFeesToClaim(uint256 _minFeesToClaim) external;
-
-    function minFeesToClaim() external view returns (uint256);
-
     function setSwapTokenRatio(uint256 _swapTokenRatio) external;
 
     function swapTokenRatio() external view returns (uint256);
@@ -49,4 +45,6 @@ interface IStrategyInterface is IStrategy {
     function maxRewardsToSell() external view returns (uint256);
 
     function balanceOfRewards() external view returns (uint256);
+
+    function getClaimableFeesValue() external view returns (uint256);
 }

--- a/src/test/Management.t.sol
+++ b/src/test/Management.t.sol
@@ -127,19 +127,6 @@ contract ManagementTest is Setup {
         }
     }
 
-    function test_setMinFeesToClaim() public {
-        uint256 amount = 123e19;
-        // user cannot setMinFeesToClaim
-        vm.prank(user);
-        vm.expectRevert("!Authorized");
-        strategy.setMinFeesToClaim(amount);
-
-        // management can setMinFeesToClaim
-        vm.prank(management);
-        strategy.setMinFeesToClaim(amount);
-        assertEq(strategy.minFeesToClaim(), amount);
-    }
-
     function test_setSwapTokenRatio() public {
         uint256 swapTokenRatio = 20;
 

--- a/src/test/Rewards.t.sol
+++ b/src/test/Rewards.t.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.18;
 
 import "forge-std/console.sol";
 import {Setup} from "./utils/Setup.sol";
+import {IPair} from "../interfaces/PearlFi/IPair.sol";
+import {IPearlRouter} from "../interfaces/PearlFi/IPearlRouter.sol";
 
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
@@ -109,5 +111,83 @@ contract OperationTest is Setup {
         assertEq(pearlBalance, rewardsAbove, "!pearlBalance");
         uint256 balanceOfRewards = strategy.balanceOfRewards();
         assertEq(balanceOfRewards, pearlBalance, "!balanceOfRewards");
+    }
+
+    function test_cannotEarnLpFees() public {
+        uint256 _amount = maxFuzzAmount / 10;
+
+        vm.prank(management);
+        strategy.setMaxRewardsToSell(1e20);
+
+        // Deposit into strategy
+        mintAndDepositIntoStrategy(strategy, user, _amount);
+        checkStrategyTotals(strategy, _amount, _amount, 0);
+
+        // assert strategy doesnt have LP token, asset token
+        assertEq(
+            ERC20(strategy.asset()).balanceOf(address(strategy)),
+            0,
+            "!LPbalance"
+        );
+
+        IPair pair = IPair(strategy.asset());
+        ERC20 airdropToken;
+        ERC20 otherToken;
+        bool stable = pair.stable();
+
+        // usdr token cannot be airdropped
+        if (pair.token0() == tokenAddrs["USDR"]) {
+            airdropToken = ERC20(pair.token1());
+            otherToken = ERC20(pair.token0());
+        } else {
+            airdropToken = ERC20(pair.token0());
+            otherToken = ERC20(pair.token1());
+        }
+
+        // airdpop usdc to user
+        uint256 token0Amount;
+        if (
+            address(airdropToken) == tokenAddrs["WETH"] ||
+            address(airdropToken) == tokenAddrs["WBTC"]
+        ) {
+            // these tokens have much higher value than stables
+            token0Amount = 1 * 10 ** airdropToken.decimals();
+        } else {
+            token0Amount = 1000 * 10 ** airdropToken.decimals();
+        }
+        airdrop(airdropToken, address(user), token0Amount);
+
+        IPearlRouter pearlRouter = IPearlRouter(
+            0xcC25C0FD84737F44a7d38649b69491BBf0c7f083
+        );
+        // user approves usdc for router
+        vm.prank(user);
+        airdropToken.approve(address(pearlRouter), token0Amount);
+
+        // user swaps usdc for usdr
+        vm.prank(user);
+        pearlRouter.swapExactTokensForTokensSimple(
+            token0Amount,
+            0,
+            address(airdropToken),
+            address(otherToken),
+            stable, // stable
+            address(strategy),
+            block.timestamp
+        );
+
+        skip(2 days);
+        vm.roll(block.number + 1);
+
+        // verify there are LP fees even we have completed some swaps
+        uint256 lpFees = strategy.getClaimableFeesValue();
+        assertEq(lpFees, 0, "!lpFees");
+
+        // Deposit into strategy to trigger LP token transfer from startegy address
+        mintAndDepositIntoStrategy(strategy, user, _amount);
+
+        // assert there are no LP fees even we have completed some swaps and transfered LP token
+        lpFees = strategy.getClaimableFeesValue();
+        assertEq(lpFees, 0, "!lpFees");
     }
 }

--- a/src/test/utils/Setup.sol
+++ b/src/test/utils/Setup.sol
@@ -77,6 +77,7 @@ contract Setup is ExtendedTest, IEvents {
         vm.label(address(strategy), "strategy");
         vm.label(performanceFeeRecipient, "performanceFeeRecipient");
         vm.label(address(strategyFactory), "strategyFactory");
+        vm.label(address(user), "user");
     }
 
     function setUpStrategyFactory() public returns (IStrategyFactoryInterface) {


### PR DESCRIPTION
Removing claiming LP fees because the strategy won't earn fees while the LP token (asset) is deposited in rewards contracts. This will always be true because the strategy wants to deposit any free LP token. 

This scenario, that the strategy won't earn LP fees, is verified in the test: https://github.com/newmickymousse/pearl-compounder/compare/remove-lp-fees?expand=1#diff-3578eb44bba224505d49a4dbb09c58832fde72cf91e6b232d9dc537ca7f2c8ebR116

There is an option to claim LP fees manually if there is some edge case when the LP token is not deposited in rewards and will earn fees: https://github.com/newmickymousse/pearl-compounder/compare/remove-lp-fees?expand=1#diff-b0e30b7a85aeaef3c9ef94412789fda417aa7c9add415429a90442f9c0a647fcR588

There is already a function to check the value of claimable fees: https://github.com/newmickymousse/pearl-compounder/blob/master/src/PearlLPCompounder.sol#L252

Here is harvest tx in USDC/USDR strategy: https://polygonscan.com/tx/0x0bd68207a4cc2ea2bc5a8fa8acdeef408fc44e78a6e54899561835449505062f#eventlog
There is no [`Claim event`](https://github.com/Pearl-Finance/pearl-contracts/blob/fac7a43545c0244c210c0e86248ed4f8208e8c59/contracts/Pair.sol#L143) which means that the strategy didn't claim any fees from LP.
Here is harvest tx in DAI/USDR strategy, also no `Claim event`: https://polygonscan.com/tx/0x5e60fd6536e1bb5a48a61106bb199e170a663c9d6ec8c5ede6a42a02d05e6578#eventlog